### PR TITLE
Add tf.function decorator to support calling train_step outside Model.fit

### DIFF
--- a/capsa/bias/histogramvae.py
+++ b/capsa/bias/histogramvae.py
@@ -183,7 +183,7 @@ class HistogramVAEWrapper(BaseWrapper):
         return loss, y_hat, bias
     
 
-
+    @tf.function
     def train_step(self, data, prefix=None):
         """
         The logic for one training step.

--- a/capsa/epistemic/ensemble.py
+++ b/capsa/epistemic/ensemble.py
@@ -117,7 +117,8 @@ class EnsembleWrapper(BaseWrapper):
             )
             m.compile(optimizer[i], loss[i], metrics[i])
             self.metrics_compiled[m_name] = m
-
+    
+    @tf.function
     def train_step(self, data):
         """
         The logic for one training step.


### PR DESCRIPTION
Currently, calling wrapper train steps wihtout using Model.fit results in errors when the data passed to train_steps is numpy arrays rather than tensors. This also means that all models run only in eager mode, which causes significant slowdowns. 

Wrapping with @tf.function doesn't seem to break the Model.fit functionality and allows us to call custom train steps outside Model.fit

Note that this is only a problem when compiling the model is required, such as in the HistogramVAE and Ensemble cases, because otherwise we can use the uncompiled model and write our own train step (with a @tf.function decorator) outside capsa