### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,6 @@ sphinx:
 python:
    install:
    - requirements: requirements.txt
+   - method: pip
+     path: .
 


### PR DESCRIPTION
Configured .readthedocs.yaml to install capsa before attempting to run sphinx